### PR TITLE
Fix silent hubot on Talker

### DIFF
--- a/src/talker.coffee
+++ b/src/talker.coffee
@@ -61,6 +61,8 @@ class Talker extends Adapter
 
     @bot = bot
 
+    self.emit "connected"
+
   userForMessage: (room, message)->
     author = @userForId(message.user.id, message.user)
     author.room = room


### PR DESCRIPTION
Fix for Issue #4

It was missing a `self.emit "connected"` notification that hubot needs on latest versions.
