### PR TITLE
Syntax error

### DIFF
--- a/src/talker.coffee
+++ b/src/talker.coffee
@@ -114,14 +114,14 @@ class TalkerClient extends EventEmitter
 
     socket
 
-  write: (room, arguments) ->
+  write: (room, args) ->
     self = @
     @sockets[room]
 
     if @sockets[room].readyState != 'open'
       return @disconnect 'cannot send with readyState: ' + @sockets[room].readyState
 
-    message = JSON.stringify(arguments)
+    message = JSON.stringify(args)
     console.log "To room #{room}: #{message}"
 
     @sockets[room].write message, @encoding


### PR DESCRIPTION
I'm getting syntax errors because of the use of the keyword "arguments" used in TalkerClient.write.  Renaming to "args" seems to work fine.

```
2012-06-12T17:33:46+00:00 app[web.1]: [Tue Jun 12 2012 17:33:46 GMT+0000 (UTC)] ERROR Cannot load adapter talker - SyntaxError: In /app/node_modules/hubot-talker/src/talker.coffee, parameter name "arguments" is not allowed
2012-06-12T17:33:46+00:00 app[web.1]: SyntaxError: In /app/node_modules/hubot-talker/src/talker.coffee, parameter name "arguments" is not allowed
2012-06-12T17:33:46+00:00 app[web.1]:     at Object.anonymous (/app/node_modules/hubot/node_modules/coffee-script/lib/coffee-script/parser.js:128:18)
2012-06-12T17:33:46+00:00 app[web.1]:     at SyntaxError (unknown source)
2012-06-12T17:33:46+00:00 app[web.1]:     at new Param (/app/node_modules/hubot/node_modules/coffee-script/lib/coffee-script/nodes.js:1846:15)
2012-06-12T17:33:46+00:00 app[web.1]:     at Object.parse (/app/node_modules/hubot/node_modules/coffee-script/lib/coffee-script/parser.js:551:36)
2012-06-12T17:33:46+00:00 app[web.1]:     at /app/node_modules/hubot/node_modul
es/coffee-script/lib/coffee-script/coffee-script.js:43:20
2012-06-12T17:33:46+00:00 app[web.1]:     at Object..coffee (/app/node_modules/hubot/node_modules/coffee-script/lib/coffee-script/coffee-script.js:19:17)
2012-06-12T17:33:46+00:00 app[web.1]:     at Module.load (module.js:353:31)
2012-06-12T17:33:46+00:00 app[web.1]:     at Function._load (module.js:311:12)
2012-06-12T17:33:46+00:00 app[web.1]:     at Module.require (module.js:359:17)
2012-06-12T17:33:46+00:00 app[web.1]:     at require (module.js:375:17)
2012-06-12T17:33:47+00:00 app[web.1]: TypeError: Cannot call method 'on' of null
2012-06-12T17:33:47+00:00 app[web.1]:     at Object.<anonymous> (/app/node_modules/hubot/bin/hubot:105:19)
2012-06-12T17:33:47+00:00 app[web.1]:     at Object.<anonymous> (/app/node_modules/hubot/bin/hubot:109:4)
2012-06-12T17:33:47+00:00 app[web.1]:     at Module._compile (module.js:446:26)
2012-06-12T17:33:47+00:00 app[web.1]:     at Object.run (/app/node_modules/hubot/node_modules/coffee-script/lib/coffee-script/coffee-script.js:79:25)
2012-06-12T17:33:47+00:00 app[web.1]:     at /app/node_modules/hubot/node_modules/coffee-script/lib/coffee-script/command.js:177:29
2012-06-12T17:33:47+00:00 app[web.1]:     at /app/node_modules/hubot/node_modules/coffee-script/lib/coffee-script/command.js:152:18
2012-06-12T17:33:47+00:00 app[web.1]:     at [object Object].emit (events.js:64:17)
2012-06-12T17:33:47+00:00 app[web.1]:     at Object.oncomplete (fs.js:1188:12)
2012-06-12T17:33:47+00:00 app[web.1]:     at [object Object].<anonymous> (fs.js:123:5)
2012-06-12T17:33:48+00:00 heroku[web.1]: Process exited with status 1
2012-06-12T17:33:48+00:00 heroku[web.1]: State changed from starting to crashed
```

I'm not super familiar with node, so if this is a version mismatch or something, please let me know.

Thanks!
